### PR TITLE
Add .claudecode/ to gitignore for local Claude Code settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ dist/
 coverage/
 .vscode/
 .idea/
+.claudecode/


### PR DESCRIPTION
## Summary
- Add `.claudecode/` directory to `.gitignore`
- Prevent local Claude Code memory/settings from being tracked in the repository
- Allow developers to have project-specific Claude configurations without affecting the public repository

## Why this change?
When using Claude Code, it can create local memory files in `.claudecode/memory/local.md` for project-specific settings (like language preferences). These settings should not be committed to the public repository as they are developer-specific.

## Test plan
- [x] Verify `.claudecode/` is properly ignored by git
- [x] Confirm existing gitignore patterns still work correctly
- [x] Test that Claude Code local settings are not tracked

🤖 Generated with [Claude Code](https://claude.ai/code)