### PR TITLE
chore: bump version to 1.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "httpiq",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "httpiq",
-      "version": "1.0.1",
+      "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
         "ink": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "httpiq",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "Interactive HTTP status code quiz for your terminal",
   "main": "dist/index.js",
   "bin": {


### PR DESCRIPTION
## Summary
- Update package.json version to 1.1.0
- Sync with npm release and git tag v1.1.0

## Context
This commit was created by `npm version minor` after merging the Japanese language support feature. The npm package has already been published as v1.1.0.

## Changes
- package.json: version 1.0.1 → 1.1.0
- package-lock.json: version update

🤖 Generated with [Claude Code](https://claude.ai/code)